### PR TITLE
Add UniFi Dream Wall (UDW) to the supported-model gate

### DIFF
--- a/remote_install.sh
+++ b/remote_install.sh
@@ -66,6 +66,9 @@ udm_model() {
   "UniFi Dream Router 7")
     echo "udr7"
     ;;
+  "UniFi Dream Wall")
+    echo "udw"
+    ;;
   "UniFi Express")
     echo "ux"
     ;;
@@ -121,7 +124,7 @@ depends_on curl
 ON_BOOT_D_PATH="${DATA_DIR}/on_boot.d"
 
 case "$(udm_model)" in
-udment | ucgfiber | uxgmax | ucgult | udm | udmbeast | udmpro | udmpromax | udmse | udr | udr7 | ux | ux7 | uxgfiber)
+udment | ucgfiber | uxgmax | ucgult | udm | udmbeast | udmpro | udmpromax | udmse | udr | udr7 | udw | ux | ux7 | uxgfiber)
   echo "$(ubnt-device-info model) version $(ubnt-device-info firmware) was detected"
   echo "Installing on-boot script..."
   depends_on systemctl


### PR DESCRIPTION
## What this changes and why

`remote_install.sh` rejected the **UniFi Dream Wall**: `udm_model()` had no case
for it, so the model gate fell through to `Unsupported model: UniFi Dream Wall`
and exited. The `udm-boot.service` mechanism works on the UDW unchanged — only
the gate blocked it. This maps `"UniFi Dream Wall"` → `udw` and adds `udw` to the
supported-model allowlist. Two small additions; no behavior change for any other
model.

Reproduced on a real device: `ubnt-device-info model` = `UniFi Dream Wall`,
firmware `5.1.15`.

## Testing

- `bash -n remote_install.sh` passes.
- Mocked `ubnt-device-info` to return `UniFi Dream Wall` and ran the real
  `udm_model()` → returns `udw`; the main gate then resolves to **supported**.
- Regression: an unrecognized model (e.g. `UniFi Toaster 9000`) still maps to
  `unknown` and is still rejected.
- End-to-end on a real Dream Wall: the (unchanged) `udm-boot.service` installs,
  enables, and runs `/data/on_boot.d/*` correctly across reboots, confirming the
  mechanism itself needs no UDW-specific handling — only the gate did.

## Note

The short code from `udm_model()` is used solely as an allowlist token
(`install_on_boot_udr_se` runs for every supported model), so adding `udw` is
sufficient and consistent with the existing entries.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/unifi-utilities/unifi-common/blob/main/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/unifi-utilities/unifi-common/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes (if applicable)? — N/A: there is no unit-test harness for this shell installer; verified functionally (see **Testing**).
- [x] Have you successfully run your changes locally?

---

- [x] AI was used to generate or assist with generating this PR.

  **Tool / model:** Claude Code (Anthropic's CLI), model Claude Opus 4.8.

  **How it was used:** the AI diagnosed the model-gate omission, wrote the
  two-line patch, and drafted this PR description.

  **Manual verification:** the change was validated on a real UniFi Dream Wall
  (firmware `5.1.15`) — the boot hook installs, enables, and runs across reboots
  — and via the functional `udm_model()` test and unknown-model regression noted
  in **Testing**. All AI-generated content was reviewed before requesting review,
  and I can address review comments.
