### PR TITLE
[FR] Update installer to allow specific commit hashes

### DIFF
--- a/remote_install.sh
+++ b/remote_install.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env sh
 
+# Exact commit hash to install can be provided as an argument. Otherwise, defaults to HEAD.
+COMMIT="${1:-HEAD}"
+
 # UniFi Data Directory
 DATA_DIR="/data"
 
 # A change in the name udm-boot would need to be reflected as well in systemctl calls.
 SYSTEMCTL_PATH="/etc/systemd/system/udm-boot.service"
 SYMLINK_SYSTEMCTL="/etc/systemd/system/multi-user.target.wants/udm-boot.service"
-SERVICE_META_URL="https://raw.githubusercontent.com/unifi-utilities/unifi-common/HEAD/udm-boot.service"
+SERVICE_META_URL="https://raw.githubusercontent.com/unifi-utilities/unifi-common/${COMMIT}/udm-boot.service"
 
 # --- Functions ---
 


### PR DESCRIPTION
This is useful for installing a pinned version of unifi-common. For example, this allows for proper idempotent installation in an Ansible playbook.

This is the same approach used by https://github.com/SierraSoftworks/tailscale-unifi/blob/main/install.sh, but adapted for the fact that unifi-common does not have releases.

There's a question below about "writing new tests", but as far as I can tell unifi-common does not have any tests currently and I see no mention of testing practices or expectations in the contributing guide. Nevertheless, I left it unchecked since there are no tests included.

I have at least exercised the new argument in my own Ansible playbooks, which works even with this new commit hash from my fork thanks to the way Github shares state between forks (i.e. https://raw.githubusercontent.com/unifi-utilities/unifi-common/e14189ef401ce3ff9b4803b274c1bb8acdab63a4/udm-boot.service yields a response from my fork instead of a 404).

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/unifi-utilities/unifi-common/blob/main/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/unifi-utilities/unifi-common/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes (if applicable)?
- [x] Have you successfully run your changes locally?

---

- [ ] AI was used to generate or assist with generating this PR. _Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes_. Non-maintainers may only have one AI-assisted/generated PR open at a time.

---
